### PR TITLE
Don't reset settings between map changes

### DIFF
--- a/src/carlacore/map_control.py
+++ b/src/carlacore/map_control.py
@@ -33,14 +33,9 @@ class MapControl:
         self.__active_map = self.__map_dict[map_name]
         if map_name in ["Town15", "Town11", "Town12", "Town13"]:
             map_name += f"/{map_name}"
-        self.__client.load_world('/Game/Carla/Maps/' + map_name)
+        self.__client.load_world('/Game/Carla/Maps/' + map_name, reset_settings=False)
         time.sleep(3)
         self.__map = self.__world.get_map()
-        
-        settings = self.__world.get_settings()
-        if config.SIM_NO_RENDERING:
-            settings.no_rendering_mode = True
-            self.__world.apply_settings(settings)
 
     # Serves for debugging purposes
     def change_map(self):

--- a/src/carlacore/world.py
+++ b/src/carlacore/world.py
@@ -30,11 +30,17 @@ class World:
         self.__map = self.__map_control.get_map()
         
         self.__synchronous_mode = synchronous_mode
+        self.__no_rendering_mode = config.SIM_NO_RENDERING
+        self.__fixed_delta_seconds = 0.0
+
         if self.__synchronous_mode:
-            self.__settings = self.__world.get_settings()
-            self.__settings.synchronous_mode = True
-            self.__settings.fixed_delta_seconds = config.SIM_DELTA_SECONDS
-            self.__world.apply_settings(self.__settings)
+            self.__fixed_delta_seconds = config.SIM_DELTA_SECONDS
+
+        self.__settings = self.__world.get_settings()
+        self.__settings.synchronous_mode = self.__synchronous_mode
+        self.__settings.no_rendering_mode = self.__no_rendering_mode
+        self.__settings.fixed_delta_seconds = self.__fixed_delta_seconds
+        self.__world.apply_settings(self.__settings)
         if config.VERBOSE:
             print("World initialized!")
 


### PR DESCRIPTION
This fixes #7 

This patch will also apply synchronous_mode properly, but there is something wrong with the synchronous mode such that the program will crash during training unless you disable synchronous mode.